### PR TITLE
feat(prover-server): change result format of spec method

### DIFF
--- a/prover-server/src/server_main.rs
+++ b/prover-server/src/server_main.rs
@@ -4,7 +4,7 @@ pub mod utils;
 
 use crate::prove::{create_proof, ProofResult};
 use crate::spec::ProofType;
-use crate::utils::{kroma_err, kroma_info, kroma_msg};
+use crate::utils::{kroma_err, kroma_info};
 use clap::Parser;
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::jsonrpc_core::{ErrorCode, Result};
@@ -100,7 +100,7 @@ fn main() {
     #[cfg(feature = "mock-server")]
     io.extend_with(MockRpcImpl.to_delegate());
 
-    kroma_msg(format!("Prover server running on {endpoint}"));
+    kroma_info(format!("Prover server starting on {endpoint}"));
     let server = ServerBuilder::new(io)
         .threads(3)
         .start_http(&endpoint.parse().unwrap())

--- a/prover-server/src/server_main.rs
+++ b/prover-server/src/server_main.rs
@@ -27,9 +27,9 @@ pub trait Rpc {
     /// 3. pub chain_id: u32,
     /// 4. pub max_txs: u32,
     /// 5. pub max_call_data: u32,
-    fn spec(&self) -> Result<String> {
+    fn spec(&self) -> Result<ZkSpec> {
         let spec = ZkSpec::new(KROMA_CHAIN_ID);
-        Ok(serde_json::to_string(&spec).unwrap())
+        Ok(spec)
     }
 
     #[rpc(name = "prove")]

--- a/prover-server/src/spec.rs
+++ b/prover-server/src/spec.rs
@@ -51,7 +51,7 @@ impl ProofType {
     }
 
     /// returns enum-value mapping as a String.
-    pub fn desc() -> String {
+    pub fn desc() -> HashMap<String, i32> {
         let mut mapping = HashMap::new();
         let proof_type_vec = all::<ProofType>().collect::<Vec<_>>();
         for i in proof_type_vec {
@@ -59,13 +59,13 @@ impl ProofType {
             let value = i.to_value();
             mapping.insert(key, value);
         }
-        serde_json::to_string(&mapping).unwrap()
+        mapping
     }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
 pub struct ZkSpec {
-    pub proof_type_desc: String,
+    pub proof_type_desc: HashMap<String, i32>,
     pub degree: u32,
     pub agg_degree: u32,
     pub chain_id: u32,


### PR DESCRIPTION
Changed the output format of the spec method from string to json.
