### PR TITLE
feat(prover-sever): enhance error checking

### DIFF
--- a/bin/src/prove.rs
+++ b/bin/src/prove.rs
@@ -8,7 +8,7 @@ use std::io::Write;
 use std::path::PathBuf;
 use utils::Measurer;
 use zkevm::{
-    circuit::{EvmCircuit, StateCircuit, AGG_DEGREE, DEGREE},
+    circuit::{EvmCircuit, StateCircuit, AGG_DEGREE, DEGREE, MAX_TXS},
     io::write_file,
     prover::Prover,
     utils::{get_block_trace_from_file, load_or_create_params, load_or_create_seed},
@@ -78,6 +78,16 @@ fn main() {
     // Generating proofs for each trace
     let mut outer_timer = Measurer::new();
     for (trace_name, trace) in traces {
+        let tx_count = trace.transactions.len();
+        if tx_count > MAX_TXS {
+            panic!(
+                "{}",
+                format!(
+                    "too many transactions. MAX_TXS: {}, given transactions: {}",
+                    MAX_TXS, tx_count
+                )
+            );
+        }
         let mut out_dir = PathBuf::from(&trace_name);
         fs::create_dir_all(&out_dir).unwrap();
 

--- a/prover-server/src/mock_client.rs
+++ b/prover-server/src/mock_client.rs
@@ -50,8 +50,7 @@ async fn test_request_proof(cli: HttpClient, proof_type: ProofType) -> bool {
 async fn test_request_spec(cli: HttpClient) -> bool {
     kroma_info("Send 'spec' request to prover-server");
     let params = rpc_params![];
-    let response: String = cli.request("spec", params).await.unwrap();
-    let zk_spec: ZkSpec = serde_json::from_str(&response).unwrap();
+    let zk_spec: ZkSpec = cli.request("spec", params).await.unwrap();
 
     kroma_info(format!(
         "Got: \

--- a/prover-server/src/server_main.rs
+++ b/prover-server/src/server_main.rs
@@ -131,6 +131,7 @@ fn main() {
     kroma_info(format!("Prover server starting on {endpoint}"));
     let server = ServerBuilder::new(io)
         .threads(3)
+        .max_request_body_size(32_000_000)
         .start_http(&endpoint.parse().unwrap())
         .unwrap();
 

--- a/zkevm/src/circuit.rs
+++ b/zkevm/src/circuit.rs
@@ -36,13 +36,13 @@ const MAX_EXP_STEPS: usize = 10_000;
 */
 
 ////// params for degree = 20 ////////////
-pub static DEGREE: Lazy<usize> = Lazy::new(|| read_env_var("DEGREE", 20));
-pub const MAX_TXS: usize = 25;
+pub static DEGREE: Lazy<usize> = Lazy::new(|| read_env_var("DEGREE", 21));
+pub const MAX_TXS: usize = 100;
 const MAX_INNER_BLOCKS: usize = 1;
-pub const MAX_CALLDATA: usize = 400_000;
-const MAX_RWS: usize = 1_000_000;
-const MAX_KECCAK_ROWS: usize = 524_000;
-const MAX_EXP_STEPS: usize = 10_000;
+pub const MAX_CALLDATA: usize = 2_000_000;
+const MAX_RWS: usize = 2_000_000;
+const MAX_KECCAK_ROWS: usize = 1_000_000;
+const MAX_EXP_STEPS: usize = 100_000;
 
 pub static CHAIN_ID: Lazy<u64> = Lazy::new(|| read_env_var("CHAIN_ID", 2357));
 pub static AGG_DEGREE: Lazy<usize> = Lazy::new(|| read_env_var("AGG_DEGREE", 26));


### PR DESCRIPTION
* update constants related to generate proof. (e.g., MAX_TXS, MAX_CALLDATA, etc)
* check if tx count from trace is smaller than MAX_TXS before starting proof creation.
* check if chain id in trace equals to prover's chain id.
* if requested with an incorrect prove type, prover returns error before initiating a trace object.
* detailed an error message in response.