### PR TITLE
build: bump-up-zkevm-version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -553,7 +553,7 @@ checksum = "a3e2c3daef883ecc1b5d58c15adae93470a91d425f3532ba1695849656af3fc1"
 [[package]]
 name = "bus-mapping"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "eth-types",
  "ethers-core 0.17.0",
@@ -1483,7 +1483,7 @@ dependencies = [
 [[package]]
 name = "eth-types"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "ethers-core 0.17.0",
  "ethers-signers",
@@ -1844,7 +1844,7 @@ dependencies = [
 [[package]]
 name = "external-tracer"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "eth-types",
  "geth-utils",
@@ -2203,7 +2203,7 @@ dependencies = [
 [[package]]
 name = "gadgets"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "digest 0.7.6",
  "eth-types",
@@ -2244,7 +2244,7 @@ dependencies = [
 [[package]]
 name = "geth-utils"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "env_logger 0.9.3",
  "gobuild",
@@ -3363,7 +3363,7 @@ dependencies = [
 [[package]]
 name = "keccak256"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "env_logger 0.9.3",
  "eth-types",
@@ -3609,7 +3609,7 @@ dependencies = [
 [[package]]
 name = "mock"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "eth-types",
  "ethers-core 0.17.0",
@@ -3625,7 +3625,7 @@ dependencies = [
 [[package]]
 name = "mpt-zktrie"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "bus-mapping",
  "eth-types",
@@ -7208,7 +7208,7 @@ dependencies = [
 [[package]]
 name = "zkevm-circuits"
 version = "0.1.0"
-source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=7da6a81#7da6a81c765367b254230d911a3bd1e7103cb7a4"
+source = "git+https://github.com/kroma-network/zkevm-circuits.git?rev=6ef08f5#6ef08f5df6291999bacc523d608f91d80d199d43"
 dependencies = [
  "array-init",
  "bus-mapping",

--- a/types/Cargo.toml
+++ b/types/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.3.0"
 edition = "2021"
 
 [dependencies]
-eth-types = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "7da6a81", feature = ["kroma"]}
+eth-types = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "6ef08f5", feature = ["kroma"]}
 base64 = "0.13.0"
 blake2 = "0.10.3"
 ethers-core = "0.17.0"

--- a/zkevm/Cargo.toml
+++ b/zkevm/Cargo.toml
@@ -12,11 +12,11 @@ halo2-snark-aggregator-api = { git = "https://github.com/kroma-network/halo2-sna
 
 halo2_proofs = { git = "https://github.com/privacy-scaling-explorations/halo2.git", tag = "v2022_09_10" }
 
-bus-mapping = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "7da6a81", feature = ["kroma"] }
-eth-types = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "7da6a81", feature = ["kroma"] }
+bus-mapping = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "6ef08f5", feature = ["kroma"] }
+eth-types = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "6ef08f5", feature = ["kroma"] }
 # TODO: enable zktrie feature
-zkevm-circuits = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "7da6a81", default-features = false, features = ["test","enable-sign-verify", "kroma"] }
-mpt-zktrie = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "7da6a81" }
+zkevm-circuits = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "6ef08f5", default-features = false, features = ["test","enable-sign-verify", "kroma"] }
+mpt-zktrie = { git = "https://github.com/kroma-network/zkevm-circuits.git", rev = "6ef08f5" }
 
 rand = "0.8"
 rand_xorshift = "0.3"


### PR DESCRIPTION
Apply the zkevm-circuits with the fix for the bug in the part that assigns RLP values to the tables.