### PR TITLE
ci: enable building only insider docker environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,33 +33,6 @@ jobs:
             echo "docker-tag=${{ github.ref_name }}" >> $GITHUB_OUTPUT
           fi
 
-      - name: Install Go
-        uses: actions/setup-go@v3
-        with:
-          go-version: '>=1.20.0'
-
-      - name: Install Rust
-        run: curl https://sh.rustup.rs -sSfy | sh
-
-      - name: Add Rust to PATH
-        run: |
-          export PATH="$HOME/.cargo/bin:$PATH"
-          echo 'export PATH="$HOME/.cargo/bin:$PATH"' >> $HOME/.bashrc
-          rustc --version
-
-      - name: Verify Rust installation
-        run: rustc --version
-
-      - name: Run cargo build
-        uses: actions-rs/cargo@v1
-        with:
-          command: build
-          args: --release --bin prover-server
-
-      - name: Prepare libzktrie
-        run: |
-          cp `find ./target/release | grep libzktrie.so` .
-
       - name: Login to Docker Hub
         uses: docker/login-action@v2
         with:


### PR DESCRIPTION
# Description

This PR enables building only inside docker environment because tachyon packages aren't prepared at local CI environment.
