### PR TITLE
feat(zkevm): extend the compatible trace version

### DIFF
--- a/zkevm/src/version.rs
+++ b/zkevm/src/version.rs
@@ -8,7 +8,7 @@ pub const MINOR: u32 = 1;
 pub const PATCH: u32 = 5;
 
 /// Trace versions that are compatible with Prover.
-pub const TRACE_VERSIONS: [&str; 1] = ["0.5.1"];
+pub const TRACE_VERSIONS: [&str; 3] = ["0.5.1", "0.5.2", "0.5.3"];
 
 /// ZKEVM circuit versions that are compatible with Prover.
 pub const ZKEVM_CIRCUIT_VERSIONS: [&str; 1] = ["0.2.0"];


### PR DESCRIPTION
In this PR, the Prover has been modified to generate proofs with trace versions 0.5.2 and 0.5.3.