### PR TITLE
feat: panic if not expected params

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1088,6 +1088,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctor"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edb49164822f3ee45b17acd4a208cfc1251410cf0cad9a833234c9890774dd9f"
+dependencies = [
+ "quote",
+ "syn 2.0.17",
+]
+
+[[package]]
 name = "ctr"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4478,6 +4488,7 @@ version = "0.1.5"
 dependencies = [
  "anyhow",
  "clap 4.3.3",
+ "ctor",
  "dotenv",
  "enum-iterator",
  "env_logger 0.10.0",
@@ -6550,7 +6561,7 @@ checksum = "97fee6b57c6a41524a810daee9286c02d7752c4253064d0b05472833a438f675"
 dependencies = [
  "cfg-if 1.0.0",
  "digest 0.10.7",
- "rand 0.7.3",
+ "rand 0.8.5",
  "static_assertions",
 ]
 

--- a/prover-server/Cargo.toml
+++ b/prover-server/Cargo.toml
@@ -34,6 +34,8 @@ jsonrpc-derive = "18.0.0"
 jsonrpc-core-client = "18.0.0"
 jsonrpc-http-server = "18.0.0"
 
+[dev-dependencies]
+ctor = "0.2"
 
 [[bin]]
 name = "prover-server"

--- a/prover-server/src/prove.rs
+++ b/prover-server/src/prove.rs
@@ -10,7 +10,7 @@ use zkevm::circuit::{AGG_DEGREE, DEGREE};
 use zkevm::prover::{AggCircuitProof, Prover};
 use zkevm::utils::{load_kzg_params, load_or_create_seed};
 
-const PARAMS_DIR: &str = "./kzg_params/";
+pub const PARAMS_DIR: &str = "./kzg_params/";
 const SEED_FILE: &str = "./rng_seed";
 const OUT_PROOF_DIR: &str = "./out_proof/";
 

--- a/prover-server/src/server_main.rs
+++ b/prover-server/src/server_main.rs
@@ -2,11 +2,11 @@ use clap::Parser;
 use jsonrpc_derive::rpc;
 use jsonrpc_http_server::jsonrpc_core::{Error as JsonError, Result as JsonResult};
 use jsonrpc_http_server::ServerBuilder;
-use prove::{create_proof, ProofResult};
+use prove::{create_proof, ProofResult, PARAMS_DIR};
 use prover_server::prove;
 use prover_server::prover_error::ProverError;
 use prover_server::spec::ZkSpec;
-use prover_server::utils::{is_cancun_trace, kroma_info};
+use prover_server::utils::{is_cancun_trace, kroma_info, panic_if_kzg_params_not_found};
 use types::eth::BlockTrace;
 use utils::{check_chain_id, is_tachyon};
 use zkevm::circuit::{CHAIN_ID, MAX_TXS};
@@ -108,6 +108,7 @@ fn main() {
     env_logger::init();
 
     panic_if_wrong_circuit_version();
+    panic_if_kzg_params_not_found(PARAMS_DIR);
     let chain_id = check_chain_id();
     let args = Args::parse();
     let endpoint = args.endpoint.unwrap_or("127.0.0.1:3030".to_string());

--- a/prover-server/src/server_main.rs
+++ b/prover-server/src/server_main.rs
@@ -6,7 +6,9 @@ use prove::{create_proof, ProofResult, PARAMS_DIR};
 use prover_server::prove;
 use prover_server::prover_error::ProverError;
 use prover_server::spec::ZkSpec;
-use prover_server::utils::{is_cancun_trace, kroma_info, panic_if_kzg_params_not_found};
+use prover_server::utils::{
+    is_cancun_trace, kroma_info, panic_if_kzg_params_is_not_official, panic_if_kzg_params_not_found,
+};
 use types::eth::BlockTrace;
 use utils::{check_chain_id, is_tachyon};
 use zkevm::circuit::{CHAIN_ID, MAX_TXS};
@@ -109,6 +111,8 @@ fn main() {
 
     panic_if_wrong_circuit_version();
     panic_if_kzg_params_not_found(PARAMS_DIR);
+    panic_if_kzg_params_is_not_official(PARAMS_DIR);
+
     let chain_id = check_chain_id();
     let args = Args::parse();
     let endpoint = args.endpoint.unwrap_or("127.0.0.1:3030".to_string());

--- a/prover-server/src/utils.rs
+++ b/prover-server/src/utils.rs
@@ -1,5 +1,14 @@
+use halo2_proofs::halo2curves::{
+    bn256::{Fq, G1Affine},
+    serde::SerdeObject,
+};
 use log::{error, info};
-use std::{fmt::Display, path::Path};
+use std::{
+    fmt::Display,
+    fs::File,
+    io::{BufReader, Read},
+    path::Path,
+};
 use zkevm::circuit::{AGG_DEGREE, DEGREE};
 
 pub static KROMA_MSG_HEADER: &str = "KROMA";
@@ -34,14 +43,68 @@ pub fn panic_if_kzg_params_not_found(params_dir: &str) {
     }
 }
 
+fn check_kzg_params_official(params_dir: &str, degree: usize) -> bool {
+    let params_path = format!("{params_dir}/params{degree}");
+    let f = File::open(params_path).unwrap();
+    let reader = &mut BufReader::new(f);
+
+    let mut k = [0u8; 4];
+    reader.read_exact(&mut k[..]).unwrap();
+    let k = u32::from_le_bytes(k);
+    if degree != k as usize {
+        log::info!("not match k, expected({degree}) but {k}");
+    }
+
+    let generator_from_file = <G1Affine as SerdeObject>::read_raw_unchecked(reader);
+    if generator_from_file != G1Affine::generator() {
+        return false;
+    }
+
+    let sg_from_file = <G1Affine as SerdeObject>::read_raw_unchecked(reader);
+    sg_from_file.x
+        == Fq::from_raw([
+            0xac15e801f2b91e69,
+            0xbb3d11e31115dafb,
+            0x7f8fcae1abf6d2e4,
+            0x269350b5ecd44c00,
+        ])
+        && sg_from_file.y
+            == Fq::from_raw([
+                0xe2d29ad22f98b08c,
+                0xbfbb0d65b2ebe926,
+                0xe686071693e4fa85,
+                0x094818a234be895a,
+            ])
+}
+
+pub fn panic_if_kzg_params_is_not_official(params_dir: &str) {
+    if !check_kzg_params_official(params_dir, *DEGREE) {
+        panic!(
+            "The official kzg parameters should be used for degree {}.",
+            *DEGREE
+        )
+    }
+    if !check_kzg_params_official(params_dir, *AGG_DEGREE) {
+        panic!(
+            "The official kzg parameters should be used for degree {}.",
+            *AGG_DEGREE
+        )
+    }
+}
+
 #[cfg(test)]
 mod tests {
-    use std::fs;
     use ctor::{ctor, dtor};
+    use std::fs;
 
-    use zkevm::{circuit::{AGG_DEGREE, DEGREE}, utils::create_params};
+    use zkevm::{
+        circuit::{AGG_DEGREE, DEGREE},
+        utils::create_params,
+    };
 
-    use super::{is_cancun_trace, panic_if_kzg_params_not_found};
+    use super::{
+        is_cancun_trace, panic_if_kzg_params_is_not_official, panic_if_kzg_params_not_found,
+    };
 
     pub static TEST_PARAMS_DIR: &str = "../target/kzg_params";
 
@@ -83,5 +146,18 @@ mod tests {
     #[test]
     fn test_kzg_params_found() {
         panic_if_kzg_params_not_found(TEST_PARAMS_DIR);
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_not_official_kzg_params() {
+        panic_if_kzg_params_is_not_official(TEST_PARAMS_DIR);
+    }
+
+    #[ignore]
+    #[test]
+    // NOTE(dongchangYoo): the official params are needed for this test.
+    fn test_official_kzg_params() {
+        panic_if_kzg_params_is_not_official("../kzg_params");
     }
 }

--- a/prover-server/src/utils.rs
+++ b/prover-server/src/utils.rs
@@ -1,5 +1,6 @@
 use log::{error, info};
-use std::fmt::Display;
+use std::{fmt::Display, path::Path};
+use zkevm::circuit::{AGG_DEGREE, DEGREE};
 
 pub static KROMA_MSG_HEADER: &str = "KROMA";
 
@@ -19,11 +20,46 @@ pub fn is_cancun_trace(trace_json: &String) -> bool {
     trace_json.contains("TSTORE") || trace_json.contains("TLOAD") || trace_json.contains("MCOPY")
 }
 
+fn check_kzg_param_exists(params_dir: &str, degree: usize) -> bool {
+    let params_path = format!("{params_dir}/params{degree}");
+    Path::new(&params_path).exists()
+}
+
+pub fn panic_if_kzg_params_not_found(params_dir: &str) {
+    if !check_kzg_param_exists(params_dir, *AGG_DEGREE) {
+        panic!("kzg params for degree {} not found", *AGG_DEGREE)
+    }
+    if !check_kzg_param_exists(params_dir, *DEGREE) {
+        panic!("kzg params for degree {} not found", *DEGREE)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::fs;
+    use ctor::{ctor, dtor};
 
-    use super::is_cancun_trace;
+    use zkevm::{circuit::{AGG_DEGREE, DEGREE}, utils::create_params};
+
+    use super::{is_cancun_trace, panic_if_kzg_params_not_found};
+
+    pub static TEST_PARAMS_DIR: &str = "../target/kzg_params";
+
+    #[ctor]
+    fn setup() {
+        // Generate directory for kzg params.
+        fs::create_dir_all(TEST_PARAMS_DIR).unwrap();
+        // Generate empty params files for testing.
+        let file_path = format!("{TEST_PARAMS_DIR}/params{}", *DEGREE);
+        let _ = create_params(file_path.as_str(), 1).unwrap();
+        let file_path = format!("{TEST_PARAMS_DIR}/params{}", *AGG_DEGREE);
+        let _ = create_params(file_path.as_str(), 1).unwrap();
+    }
+
+    #[dtor]
+    fn teardown() {
+        fs::remove_dir_all(TEST_PARAMS_DIR).unwrap()
+    }
 
     #[test]
     fn test_is_cancun_trace() {
@@ -35,5 +71,17 @@ mod tests {
         assert!(is_cancun_trace(&trace_str));
         let trace_str = fs::read_to_string("../zkevm/tests/traces/wrong/tload.json").unwrap();
         assert!(is_cancun_trace(&trace_str));
+    }
+
+    #[test]
+    #[should_panic]
+    fn test_kzg_params_not_found() {
+        let params_dir = "../target/kzg_params_wrong/";
+        panic_if_kzg_params_not_found(params_dir);
+    }
+
+    #[test]
+    fn test_kzg_params_found() {
+        panic_if_kzg_params_not_found(TEST_PARAMS_DIR);
     }
 }


### PR DESCRIPTION
In this PR, the check on `kzg_params`, which is essential for proving execution, has been strengthened.